### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,4 +1,6 @@
 name: Go
+permissions:
+  contents: read
 on:
   push:
     branches: [ "master" ]


### PR DESCRIPTION
Potential fix for [https://github.com/kaduartur/config/security/code-scanning/1](https://github.com/kaduartur/config/security/code-scanning/1)

The best way to fix the problem is to add a `permissions` block to the workflow file. Since the workflow does not carry out any operations that require write permissions (such as pushing code, creating issues, or modifying pull requests), the minimal privilege required is `contents: read`. To ensure all jobs use the least privilege required, the `permissions` block should be placed at the top level, just after the name or `on` key of the workflow file (before the `jobs:` block). No modifications to the jobs or steps are needed. No imports, method definitions, or additional code is required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
